### PR TITLE
Handle partial datasets for combined membership

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclient",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "An opinionated client for RESTful APIs (particularly OpenStack's).",
   "homepage": "https://github.com/gabrielhurley/js-openclient",
   "keywords": ["client", "rest", "openstack"],


### PR DESCRIPTION
This cleans up cases where Keystone gets into inconsistent
states (via external auth drivers, etc.) and allows admins
to go on listing out project members successfully.