### PR TITLE
Add method to retrieve stack template, Avoid redirects

### DIFF
--- a/heat/v1/client.js
+++ b/heat/v1/client.js
@@ -1,6 +1,7 @@
 var base = require("../../client/base"),
     ResourcesManager = require("./resources"),
-    StacksManager = require("./stacks");
+    StacksManager = require("./stacks"),
+    TemplatesManager = require("./templates");
 
 
 var Heat = base.Client.extend({
@@ -11,6 +12,7 @@ var Heat = base.Client.extend({
     this._super(options);
     this.resources = new ResourcesManager(this);
     this.stacks = new StacksManager(this);
+    this.templates = new TemplatesManager(this);
   }
 });
 

--- a/heat/v1/stacks.js
+++ b/heat/v1/stacks.js
@@ -6,6 +6,16 @@ var StacksManager = base.Manager.extend({
   namespace: "stacks",
   use_raw_data: true,
 
+  get_base_url: function (params) {
+    var base_url = this._super(params);
+
+    if (params.id !== null && params.name != null) {
+      base_url = urljoin(base_url, params.name);
+    }
+
+    return base_url;
+  },
+
   create: function (params, callback) {
     var success = params.success,
         error = params.error,

--- a/heat/v1/stacks.js
+++ b/heat/v1/stacks.js
@@ -1,5 +1,6 @@
 var async = require('async'),
-    base = require("../../client/base");
+    base = require("../../client/base"),
+    urljoin = require("../../client/utils").urljoin;
 
 
 var StacksManager = base.Manager.extend({

--- a/heat/v1/stacks.js
+++ b/heat/v1/stacks.js
@@ -38,7 +38,7 @@ var StacksManager = base.Manager.extend({
     });
 
     this._super(params, function (err, result, xhr) {
-      if (err) return manager.safe_complete(err, null, null, params, callback);
+      if (err) return manager.safe_complete(err, null, xhr, { error: error }, callback);
       manager.get({
         url: xhr.getResponseHeader('location'),
         success: success,

--- a/heat/v1/stacks.js
+++ b/heat/v1/stacks.js
@@ -88,7 +88,22 @@ var StacksManager = base.Manager.extend({
     params.url = this.urljoin(this.get_base_url(params), data.stack_name, params.id);
     params.headers['Content-Length'] = 0;
     this._super(params, callback);
-  }
+  },
+
+  _action: function (params, action, info, callback) {
+    var url = urljoin(this.get_base_url(params), params.id || params.data.id, "actions");
+    if (params.data && params.data.id) delete params.data.id;
+    params = this.prepare_params(params, url, "singular");
+    params.data[action] = info || null;
+    return this.client.post(params, callback);
+  },
+
+  suspend: function (params, callback) { return this._action(params, "suspend", null, callback); },
+  resume: function (params, callback) { return this._action(params, "resume", null, callback); },
+
+  cancel_update: function (params, callback) { return this._action(params, "cancel_update", null, callback); },
+
+  check: function (params, callback) { return this._actions(params, "check", null, callback); }
 });
 
 

--- a/heat/v1/templates.js
+++ b/heat/v1/templates.js
@@ -1,0 +1,27 @@
+var base = require("../../client/base"),
+    utils = require("../../client/utils"),
+    urljoin = require("../../client/utils").urljoin;
+
+
+var TemplatesManager = base.Manager.extend({
+  namespace: "/stacks/{stack_id}/template",
+  plural: "templates",
+
+  prepare_namespace: function (params) {
+    params.data = params.data || {};
+
+    var stack_id = params.data.stack_id;
+    delete params.data.stack_id;
+    return utils.interpolate(this.namespace, {stack_id: stack_id});
+  },
+
+  get: function (params, callback) {
+    var url = urljoin(this.get_base_url(params));
+    params = this.prepare_params(params, url);
+    this.client.get(params, callback);
+  }
+
+});
+
+
+module.exports = TemplatesManager;

--- a/heat/v1/templates.js
+++ b/heat/v1/templates.js
@@ -1,6 +1,5 @@
 var base = require("../../client/base"),
-    utils = require("../../client/utils"),
-    urljoin = require("../../client/utils").urljoin;
+    utils = require("../../client/utils");
 
 
 var TemplatesManager = base.Manager.extend({
@@ -16,7 +15,7 @@ var TemplatesManager = base.Manager.extend({
   },
 
   get: function (params, callback) {
-    var url = urljoin(this.get_base_url(params));
+    var url = this.get_base_url(params);
     params = this.prepare_params(params, url);
     this.client.get(params, callback);
   }

--- a/heat/v1/templates.js
+++ b/heat/v1/templates.js
@@ -9,9 +9,9 @@ var TemplatesManager = base.Manager.extend({
 
   prepare_namespace: function (params) {
     params.data = params.data || {};
-
     var stack_id = params.data.stack_id;
     delete params.data.stack_id;
+
     return utils.interpolate(this.namespace, {stack_id: stack_id});
   },
 


### PR DESCRIPTION
Allows the user to retrieve the heat template that a stack was created with. The path was ending with a /, which breaks the API call, so I set the URL in templates.js.

If you go to the path ../stacks/<stack_id>, you are (supposed to be) redirected to the proper path, ../stacks/<stack_name>/<stack_id>. Whether it's a bug with our deployment or OpenStack in general, the redirect for stack updates doesn't work. This change allows the user to go directly to the correct path by specifying the stack name.
